### PR TITLE
Clean up PR workflow and add manual deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy & Verify
 on:
   push:
     branches: [master]
+  workflow_dispatch:  # allows manual triggering from the Actions tab
 
 jobs:
   # ── Job 1: push files to S3 ─────────────────────────────────────────────

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,13 +97,8 @@ jobs:
     needs: [static-tests, security-scan]
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write  # allows committing generated Linux baselines back to the branch
-
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}  # check out the PR branch, not the merge commit
 
       - uses: actions/setup-node@v4
         with:
@@ -115,21 +110,6 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-
-      # Generate Linux baselines on first run, then compare on all subsequent runs.
-      # --update-snapshots writes PNGs when they don't exist and exits 0,
-      # so this step never fails due to missing baselines.
-      - name: Generate missing visual baselines
-        run: npx playwright test tests/e2e/visual.spec.js --update-snapshots
-        continue-on-error: true
-
-      - name: Commit baselines if newly generated
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add tests/e2e/visual.spec.js-snapshots/
-          git diff --cached --quiet || git commit -m "chore: add Linux visual regression baselines [skip ci]" && git push
-        continue-on-error: true
 
       - name: Run Playwright tests
         run: npm run test:e2e


### PR DESCRIPTION
## Summary

- **pr.yml**: removes the temporary baseline-generation steps (generate + commit Linux PNGs) that were needed for the first PR run. Linux snapshots are now committed to master, so subsequent PRs just compare against them directly. Also removes the `contents: write` permission and `head_ref` checkout that were only needed for committing back.
- **deploy.yml**: adds `workflow_dispatch` trigger so the deploy pipeline can be manually triggered from the Actions tab without needing a push to master — useful for testing the OIDC setup and debugging.

## Test plan

- [ ] PR checks run cleanly — Playwright visual tests pass against committed Linux baselines without trying to generate or commit anything
- [ ] After merge: manually trigger the Deploy & Verify workflow from the Actions tab to verify the OIDC auth, S3 sync, and CloudFront invalidation work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)