### PR TITLE
Fix: add cloudfront:GetInvalidation permission to deploy role

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -370,6 +370,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
 
     actions = [
       "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",  # required for `aws cloudfront wait invalidation-completed`
     ]
 
     resources = [aws_cloudfront_distribution.site.arn]


### PR DESCRIPTION
## Summary

`aws cloudfront wait invalidation-completed` polls using `cloudfront:GetInvalidation` under the hood. The IAM inline policy on `portfolio-github-actions-deploy` only granted `cloudfront:CreateInvalidation`, causing the wait step to fail with AccessDenied.

Adds `cloudfront:GetInvalidation` to the Terraform IAM policy definition to keep it in sync with the manual fix applied directly in the AWS console.

## Test plan

- [ ] After merge, deploy workflow runs to completion — invalidation wait step passes without AccessDenied
- [ ] Canary rollback flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)