### PR TITLE
fix: no tap feedback on iOS for hamburger, nav links, and logo

### DIFF
--- a/ai-engineering.html
+++ b/ai-engineering.html
@@ -386,6 +386,6 @@
   </div>
 </footer>
 
-<script src="js/app.js"></script>
+<script src="js/app.js" fetchpriority="high"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -643,6 +643,6 @@
   </div>
 </footer>
 
-<script src="js/app.js"></script>
+<script src="js/app.js" fetchpriority="high"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,13 @@
 
 function initPortfolio() {
 
+  /* ── iOS/WebKit: enable :active and :hover on tap ──
+     WebKit (Safari, and every iOS browser incl. Chrome — Apple mandates
+     WebKit under the hood there) only applies :active/:hover on touch if a
+     touchstart listener exists somewhere on the page. Without this, tap
+     feedback (hamburger, nav links, logo) silently never fires on iOS. */
+  document.body.addEventListener('touchstart', function () {}, { passive: true });
+
   /* ── Fonts: activate preloaded Google Fonts stylesheet ──
      The <link id="google-fonts"> in <head> uses rel="preload" to start the
      download without blocking render.  CSP script-src 'self' forbids inline

--- a/styles/main.css
+++ b/styles/main.css
@@ -166,7 +166,13 @@ button { font-family: inherit; }
   -webkit-text-fill-color: transparent;
   background-clip: text;
   flex-shrink: 0;
+  display: inline-block;
+  transition: transform var(--transition), opacity var(--transition);
+  -webkit-tap-highlight-color: transparent;
 }
+/* transform/opacity, not color — the gradient text-fill makes a color-based
+   :active state invisible, so the tap feedback has to be geometric instead */
+.nav__logo:active { transform: scale(0.92); opacity: 0.75; }
 
 .nav__links {
   display: flex;
@@ -258,6 +264,7 @@ button { font-family: inherit; }
   border-radius: 50%;
   pointer-events: none;
   filter: blur(90px);
+  will-change: transform;
 }
 .hero__orb--1 {
   width: 65rem; height: 65rem;
@@ -840,6 +847,12 @@ button { font-family: inherit; }
   .hero__stats { gap: 3.2rem; }
   .hero__ctas  { gap: 1rem; }
   .hero .btn   { padding: 1rem 1.8rem; font-size: 1.35rem; }
+
+  /* Three continuously-animated blur(90px) layers are expensive to
+     composite on mobile GPUs, and can visibly delay input responsiveness
+     (e.g. tapping the hamburger) for the first few seconds after load —
+     purely decorative, so disable rather than tune. */
+  .hero__orb { animation: none; }
 
   /* About */
   .about__photo { width: 17rem; height: 17rem; }

--- a/testing.html
+++ b/testing.html
@@ -770,6 +770,6 @@
   </div>
 </footer>
 
-<script src="js/app.js"></script>
+<script src="js/app.js" fetchpriority="high"></script>
 </body>
 </html>


### PR DESCRIPTION
Root cause: iOS WebKit (Safari, and every iOS browser including Chrome — Apple mandates WebKit there) only applies :active/:hover on tap if a touchstart listener exists somewhere on the page. app.js only registered click/keydown listeners, so none of the :active styles added in a previous pass were actually firing on iOS — they worked fine in Chromium-based testing, which masked this. Fixed with the standard no-op touchstart listener on document.body.

Also fixes a real, separate gap: .nav__logo ("SS") never had an :active state at all. Since it's rendered via background-clip: text (gradient fill), a color-based :active wouldn't be visible anyway — used transform/opacity instead.

Two additional low-risk mitigations for the reported "hamburger becomes responsive after a few seconds, or after scrolling" pattern, since a scroll gesture would also prime iOS's touch handling and could fully explain the timing on its own even without these:
- Disable the three continuously-animated blur(90px) hero orbs on mobile (max-width: 768px) — expensive to composite on weaker GPUs, purely decorative, safe to drop.
- fetchpriority="high" on the app.js script tag, so it doesn't lose bandwidth priority to concurrently-loading Google Fonts requests on slow connections.

Verified: 106 Jest + 204 Playwright passing. Could not fully reproduce the multi-second delay under CDP CPU/network throttling (tried both, inconclusive) — real device GPU/network variance exceeds what emulation captures. The touchstart fix is the highest-confidence change given this is confirmed to be iOS.