### PR TITLE
chore: ignore MCP/browser scratch artifacts and local skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,17 @@ dist
 # Playwright
 playwright-report/
 test-results/
+.playwright-mcp/
+
+# Ad-hoc screenshots dropped at repo root during manual/MCP-driven browser
+# verification — never a deliverable. Anchored to root so images/**/*.png
+# (real committed assets, e.g. images/logos/) stays tracked.
+/*.png
+
+# Local Claude Code skill installs (npx skills add ...) — machine-local
+# tooling config, not meant to ship with the site.
+.agents/
+skills-lock.json
 
 # Claude Code
 .claude/


### PR DESCRIPTION
## Summary
- Add `.gitignore` entries for `.playwright-mcp/`, ad-hoc root-level `*.png` screenshots (scoped so `images/**/*.png` stays tracked), `.agents/`, and `skills-lock.json`.
- Follow-up cleanup after PR #49 — these were untracked scratch/tooling artifacts left in the working tree.

## Test plan
- [ ] `git status` stays clean after running a local Playwright MCP verification pass or `npx skills add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)